### PR TITLE
CHUKWA-780 Chukwa master branch failing with RAT unapproved licsenses

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -753,121 +753,129 @@
                     </execution>
                 </executions>
                 <configuration>
-                    <numUnapprovedLicenses>0</numUnapprovedLicenses>
-                    <excludes>
-			            <!-- notice files -->
-			            <exclude>CHANGES.txt</exclude>
-			            <exclude>README.md</exclude>
+                  <numUnapprovedLicenses>0</numUnapprovedLicenses>
+                  <excludes>
+  			            <!-- notice files -->
+  			            <exclude>CHANGES.txt</exclude>
+  			            <exclude>README.md</exclude>
 
-			            <!-- generated files -->
-			            <exclude>bin/VERSION</exclude>
-			            <exclude>**/target/**</exclude>
-			            <exclude>**/.classpath</exclude>
-			            <exclude>**/.project</exclude>
-			            <exclude>**/.settings/**</exclude>
+  			            <!-- generated files -->
+  			            <exclude>bin/VERSION</exclude>
+  			            <exclude>**/target/**</exclude>
+  			            <exclude>**/.classpath</exclude>
+  			            <exclude>**/.project</exclude>
+  			            <exclude>**/.settings/**</exclude>
 
-			            <!-- Data files -->
-			            <exclude>conf/agents</exclude>
-			            <exclude>conf/alert</exclude>
-			            <exclude>conf/auth.conf</exclude>
-			            <exclude>conf/collectors</exclude>
-			            <exclude>conf/hbase.schema</exclude>
-			            <exclude>conf/initial_adaptors</exclude>
-			            <exclude>conf/jmxremote.access</exclude>
-			            <exclude>conf/jmxremote.password</exclude>
-			            <exclude>contrib/solr/logs/conf/_schema_analysis_stopwords_english.json</exclude>
-			            <exclude>contrib/solr/logs/conf/_schema_analysis_synonyms_english.json</exclude>
-			            <exclude>src/main/web/hicc/descriptors/**</exclude>
-			            <exclude>src/main/web/hicc/views/**</exclude>
+  			            <!-- Data files -->
+  			            <exclude>conf/agents</exclude>
+  			            <exclude>conf/alert</exclude>
+  			            <exclude>conf/auth.conf</exclude>
+  			            <exclude>conf/collectors</exclude>
+  			            <exclude>conf/hbase.schema</exclude>
+  			            <exclude>conf/initial_adaptors</exclude>
+  			            <exclude>conf/jmxremote.access</exclude>
+  			            <exclude>conf/jmxremote.password</exclude>
+  			            <exclude>contrib/solr/logs/conf/_schema_analysis_stopwords_english.json</exclude>
+  			            <exclude>contrib/solr/logs/conf/_schema_analysis_synonyms_english.json</exclude>
+  			            <exclude>src/main/web/hicc/descriptors/**</exclude>
+  			            <exclude>src/main/web/hicc/views/**</exclude>
 
-			            <!-- Test samples -->
-			            <exclude>src/test/resources/Hadoop18JobHistoryLog.txt</exclude>
-			            <exclude>src/test/resources/TestJobLog.txt</exclude>
-			            <exclude>test/samples/ClientTrace.log</exclude>
-			            <exclude>test/samples/Iostat.log</exclude>
-			            <exclude>test/samples/JobHistory.log</exclude>
+  			            <!-- Test samples -->
+  			            <exclude>src/test/resources/Hadoop18JobHistoryLog.txt</exclude>
+  			            <exclude>src/test/resources/TestJobLog.txt</exclude>
+  			            <exclude>test/samples/ClientTrace.log</exclude>
+  			            <exclude>test/samples/Iostat.log</exclude>
+  			            <exclude>test/samples/JobHistory.log</exclude>
 
-			            <!-- bsd licensed files -->
-			            <exclude>contrib/solr/logs/conf/lang/stopwords_da.txt</exclude>
-			            <exclude>contrib/solr/logs/conf/lang/stopwords_de.txt</exclude>
-			            <exclude>contrib/solr/logs/conf/lang/stopwords_es.txt</exclude>
-			            <exclude>contrib/solr/logs/conf/lang/stopwords_fa.txt</exclude>
-			            <exclude>contrib/solr/logs/conf/lang/stopwords_fi.txt</exclude>
-			            <exclude>contrib/solr/logs/conf/lang/stopwords_fr.txt</exclude>
-			            <exclude>contrib/solr/logs/conf/lang/stopwords_hi.txt</exclude>
-			            <exclude>contrib/solr/logs/conf/lang/stopwords_hu.txt</exclude>
-			            <exclude>contrib/solr/logs/conf/lang/stopwords_it.txt</exclude>
-			            <exclude>contrib/solr/logs/conf/lang/stopwords_nl.txt</exclude>
-			            <exclude>contrib/solr/logs/conf/lang/stopwords_no.txt</exclude>
-			            <exclude>contrib/solr/logs/conf/lang/stopwords_pt.txt</exclude>
-			            <exclude>contrib/solr/logs/conf/lang/stopwords_ru.txt</exclude>
-			            <exclude>contrib/solr/logs/conf/lang/stopwords_sv.txt</exclude>
-			            <exclude>src/main/web/hicc/js/jquery*</exclude>
-			            <exclude>src/main/web/hicc/home/js/jquery.js</exclude>
-			            <exclude>src/main/web/hicc/css/iui.css</exclude>
-			            <exclude>src/main/web/hicc/js/behaviour.js</exclude>
-			            <exclude>src/main/web/hicc/js/heatmap.js</exclude>
-			            <exclude>src/main/web/hicc/js/iui.js</exclude>
-			            <exclude>src/main/web/hicc/js/yahoo-dom-event.js</exclude>
-			            <exclude>src/main/web/hicc/js/treeview-min.js</exclude>
-                                    <exclude>src/main/resources/ESAPI.properties</exclude>
+  			            <!-- bsd licensed files -->
+  			            <exclude>contrib/solr/logs/conf/lang/stopwords_da.txt</exclude>
+  			            <exclude>contrib/solr/logs/conf/lang/stopwords_de.txt</exclude>
+  			            <exclude>contrib/solr/logs/conf/lang/stopwords_es.txt</exclude>
+  			            <exclude>contrib/solr/logs/conf/lang/stopwords_fa.txt</exclude>
+  			            <exclude>contrib/solr/logs/conf/lang/stopwords_fi.txt</exclude>
+  			            <exclude>contrib/solr/logs/conf/lang/stopwords_fr.txt</exclude>
+  			            <exclude>contrib/solr/logs/conf/lang/stopwords_hi.txt</exclude>
+  			            <exclude>contrib/solr/logs/conf/lang/stopwords_hu.txt</exclude>
+  			            <exclude>contrib/solr/logs/conf/lang/stopwords_it.txt</exclude>
+  			            <exclude>contrib/solr/logs/conf/lang/stopwords_nl.txt</exclude>
+  			            <exclude>contrib/solr/logs/conf/lang/stopwords_no.txt</exclude>
+  			            <exclude>contrib/solr/logs/conf/lang/stopwords_pt.txt</exclude>
+  			            <exclude>contrib/solr/logs/conf/lang/stopwords_ru.txt</exclude>
+  			            <exclude>contrib/solr/logs/conf/lang/stopwords_sv.txt</exclude>
+  			            <exclude>src/main/web/hicc/js/jquery*</exclude>
+  			            <exclude>src/main/web/hicc/home/js/jquery.js</exclude>
+                    <exclude>src/main/web/hicc/css/jquery.circliful.css</exclude>
+  			            <exclude>src/main/web/hicc/css/iui.css</exclude>
+  			            <exclude>src/main/web/hicc/js/behaviour.js</exclude>
+  			            <exclude>src/main/web/hicc/js/heatmap.js</exclude>
+  			            <exclude>src/main/web/hicc/js/iui.js</exclude>
+  			            <exclude>src/main/web/hicc/js/yahoo-dom-event.js</exclude>
+  			            <exclude>src/main/web/hicc/js/treeview-min.js</exclude>
+                    <exclude>src/main/resources/ESAPI.properties</exclude>
 
-			            <!-- MIT licensed files -->
-			            <exclude>contrib/solr/logs/conf/velocity/jquery.autocomplete.js</exclude>
-			            <exclude>src/main/web/hicc/css/flexigrid/flexigrid.css</exclude>
-			            <exclude>src/main/web/hicc/css/timeline.css</exclude>
-			            <exclude>src/main/web/hicc/lib/timeline/**</exclude>
-			            <exclude>lib/agent.dict</exclude>
-			            <exclude>lib/collector.dict</exclude>
-			            <exclude>lib/confspellcheck-README</exclude>
-			            <exclude>lib/json-README.txt</exclude>
-			            <exclude>src/main/web/hicc/js/ajaxtree.js</exclude>
-			            <exclude>src/main/web/hicc/js/flexigrid.js</exclude>
-			            <exclude>src/main/web/hicc/js/flexigrid.pack.js</exclude>
-			            <exclude>src/main/web/hicc/js/workspace/builder.js</exclude>
-			            <exclude>src/main/web/hicc/js/workspace/controls.js</exclude>
-			            <exclude>src/main/web/hicc/js/workspace/dragdrop.js</exclude>
-			            <exclude>src/main/web/hicc/js/workspace/effects.js</exclude>
-			            <exclude>src/main/web/hicc/js/workspace/scriptaculous.js</exclude>
-			            <exclude>src/main/web/hicc/js/workspace/slider.js</exclude>
-			            <exclude>src/main/web/hicc/js/workspace/sound.js</exclude>
-			            <exclude>src/main/web/hicc/js/org/tool-man/*</exclude>
-			            <exclude>src/main/web/hicc/js/timeframe.js</exclude>
-			            <exclude>src/main/web/hicc/js/workspace/prototype.js</exclude>
-			            <exclude>src/main/web/hicc/js/jquery.flot.pack.js</exclude>
-			            <exclude>src/main/web/hicc/js/gsv.js</exclude>
-			            <exclude>src/main/web/hicc/js/bootstrap.min.js</exclude>
-			            <exclude>src/main/web/hicc/js/js-cookie.js</exclude>
-			            <exclude>src/main/web/hicc/css/bootstrap-theme.css.map</exclude>
-			            <exclude>src/main/web/hicc/css/bootstrap-theme.min.css</exclude>
-			            <exclude>src/main/web/hicc/css/bootstrap.min.css</exclude>
-			            <exclude>src/main/web/hicc/fonts/glyphicons-halflings-regular.svg</exclude>
-			            <exclude>src/main/web/hicc/home/js/jquery.gridster.min.js</exclude>
-			            <exclude>src/main/web/hicc/home/js/jquery.gridster.with-extras.min.js</exclude>
-			            <exclude>src/main/web/hicc/home/css/jquery.gridster.css</exclude>
-			            <exclude>src/main/web/hicc/home/css/jquery.gridster.min.css</exclude>
-			            <exclude>src/main/web/hicc/home/js/typeahead.bundle.js</exclude>
-			            <exclude>src/main/web/hicc/home/js/classie.js</exclude>
-			            <exclude>src/main/web/hicc/home/js/gnmenu.js</exclude>
-			            <exclude>src/main/web/hicc/home/js/modernizr.custom.js</exclude>
-                                    <exclude>src/main/web/hicc/ajax-solr/chukwa/css/jquery-ui.min.css</exclude>
-                                    <exclude>src/main/web/hicc/ajax-solr/chukwa/css/jquery-ui.structure.min.css</exclude>
-                                    <exclude>src/main/web/hicc/ajax-solr/chukwa/css/jquery-ui.theme.min.css</exclude>
-                                    <exclude>src/main/web/hicc/ajax-solr/chukwa/js/jquery-ui.min.js</exclude>
-                                    <exclude>src/main/web/hicc/ajax-solr/chukwa/js/require.min.js</exclude>
-                                    <exclude>src/main/web/hicc/home/css/select2.min.css</exclude>
-                                    <exclude>src/main/web/hicc/home/js/select2.min.js</exclude>
+  			            <!-- MIT licensed files -->
+  			            <exclude>contrib/solr/logs/conf/velocity/jquery.autocomplete.js</exclude>
+  			            <exclude>src/main/web/hicc/css/flexigrid/flexigrid.css</exclude>
+  			            <exclude>src/main/web/hicc/css/timeline.css</exclude>
+  			            <exclude>src/main/web/hicc/lib/timeline/**</exclude>
+  			            <exclude>lib/agent.dict</exclude>
+  			            <exclude>lib/collector.dict</exclude>
+  			            <exclude>lib/confspellcheck-README</exclude>
+  			            <exclude>lib/json-README.txt</exclude>
+  			            <exclude>src/main/web/hicc/js/ajaxtree.js</exclude>
+  			            <exclude>src/main/web/hicc/js/flexigrid.js</exclude>
+  			            <exclude>src/main/web/hicc/js/flexigrid.pack.js</exclude>
+  			            <exclude>src/main/web/hicc/js/workspace/builder.js</exclude>
+  			            <exclude>src/main/web/hicc/js/workspace/controls.js</exclude>
+  			            <exclude>src/main/web/hicc/js/workspace/dragdrop.js</exclude>
+  			            <exclude>src/main/web/hicc/js/workspace/effects.js</exclude>
+  			            <exclude>src/main/web/hicc/js/workspace/scriptaculous.js</exclude>
+  			            <exclude>src/main/web/hicc/js/workspace/slider.js</exclude>
+  			            <exclude>src/main/web/hicc/js/workspace/sound.js</exclude>
+  			            <exclude>src/main/web/hicc/js/org/tool-man/*</exclude>
+  			            <exclude>src/main/web/hicc/js/timeframe.js</exclude>
+  			            <exclude>src/main/web/hicc/js/workspace/prototype.js</exclude>
+  			            <exclude>src/main/web/hicc/js/jquery.flot.pack.js</exclude>
+  			            <exclude>src/main/web/hicc/js/gsv.js</exclude>
+  			            <exclude>src/main/web/hicc/js/bootstrap.min.js</exclude>
+  			            <exclude>src/main/web/hicc/js/js-cookie.js</exclude>
+  			            <exclude>src/main/web/hicc/css/bootstrap-theme.css.map</exclude>
+  			            <exclude>src/main/web/hicc/css/bootstrap-theme.min.css</exclude>
+  			            <exclude>src/main/web/hicc/css/bootstrap.min.css</exclude>
+  			            <exclude>src/main/web/hicc/fonts/glyphicons-halflings-regular.svg</exclude>
+  			            <exclude>src/main/web/hicc/home/js/jquery.gridster.min.js</exclude>
+  			            <exclude>src/main/web/hicc/home/js/jquery.gridster.with-extras.min.js</exclude>
+  			            <exclude>src/main/web/hicc/home/css/jquery.gridster.css</exclude>
+  			            <exclude>src/main/web/hicc/home/css/jquery.gridster.min.css</exclude>
+  			            <exclude>src/main/web/hicc/home/js/typeahead.bundle.js</exclude>
+  			            <exclude>src/main/web/hicc/home/js/classie.js</exclude>
+  			            <exclude>src/main/web/hicc/home/js/gnmenu.js</exclude>
+  			            <exclude>src/main/web/hicc/home/js/modernizr.custom.js</exclude>
+                    <exclude>src/main/web/hicc/ajax-solr/chukwa/css/jquery-ui.min.css</exclude>
+                    <exclude>src/main/web/hicc/ajax-solr/chukwa/css/jquery-ui.structure.min.css</exclude>
+                    <exclude>src/main/web/hicc/ajax-solr/chukwa/css/jquery-ui.theme.min.css</exclude>
+                    <exclude>src/main/web/hicc/ajax-solr/chukwa/js/jquery-ui.min.js</exclude>
+                    <exclude>src/main/web/hicc/ajax-solr/chukwa/js/require.min.js</exclude>
+                    <exclude>src/main/web/hicc/home/css/select2.min.css</exclude>
+                    <exclude>src/main/web/hicc/home/js/select2.min.js</exclude>
+                    <exclude>src/main/web/hicc/css/font-awesome.min.css</exclude>
 
-			            <!-- Creative Commons licensed files -->
-			            <exclude>src/main/web/hicc/js/autoHeight.js</exclude>
+  			            <!-- Creative Commons licensed files -->
+  			            <exclude>src/main/web/hicc/js/autoHeight.js</exclude>
 
-			            <!-- Public Domain -->
-			            <exclude>src/main/web/hicc/js/base64.js</exclude>
-			            <exclude>src/main/web/hicc/js/canvas2image.js</exclude>
-			            <exclude>src/main/web/hicc/js/json.js</exclude>
-			            <exclude>src/main/web/hicc/home/fonts/codropsicons/*</exclude>
-			            <exclude>src/main/web/hicc/home/fonts/ecoicons/*</exclude>
-                    </excludes>
+  			            <!-- Public Domain -->
+  			            <exclude>src/main/web/hicc/js/base64.js</exclude>
+  			            <exclude>src/main/web/hicc/js/canvas2image.js</exclude>
+  			            <exclude>src/main/web/hicc/js/json.js</exclude>
+  			            <exclude>src/main/web/hicc/home/fonts/codropsicons/*</exclude>
+  			            <exclude>src/main/web/hicc/home/fonts/ecoicons/*</exclude>
+
+                    <!-- DO WHAT THE FUCK YOU WANT TO PUBLIC LICENSE Version 2, December 2004 -->
+                    <exclude>src/main/web/hicc/css/chartist.css</exclude>
+                    <exclude>src/main/web/hicc/css/chartist.css.map</exclude>
+                    <exclude>src/main/web/hicc/js/chartist.min.js</exclude>
+                    <exclude>src/main/web/hicc/js/chartist.min.js.map</exclude>                    
+                  </excludes>
                 </configuration>
             </plugin>
         </plugins>

--- a/src/main/web/hicc/apps/pie.js
+++ b/src/main/web/hicc/apps/pie.js
@@ -1,8 +1,24 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 var data = {
   labels: ['Mapreduce', 'HBase', 'Hive', 'Spark', 'BigSQL', 'R'],
   series: [25, 19, 21,13, 12, 11]
 };
-
 var options = {
   labelInterpolationFnc: function(value) {
     return value[0]

--- a/src/main/web/hicc/timeline/js/main.js
+++ b/src/main/web/hicc/timeline/js/main.js
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 (function() {
   $(document).ready(function() {
     var timelineAnimate;


### PR DESCRIPTION
This patch addresses https://issues.apache.org/jira/browse/CHUKWA-780 folks.
It also sorts out a bit of XML formatting.
Once patch is applied I am not getting successful build
```
...
[INFO] Installing /usr/local/chukwa_gh/target/chukwa-0.7.0-SNAPSHOT-client.jar to /Users/lmcgibbn/.m2/repository/org/apache/chukwa/chukwa/0.7.0-SNAPSHOT/chukwa-0.7.0-SNAPSHOT-client.jar
[INFO] Installing /usr/local/chukwa_gh/target/chukwa-0.7.0.tar.gz to /Users/lmcgibbn/.m2/repository/org/apache/chukwa/chukwa/0.7.0-SNAPSHOT/chukwa-0.7.0-SNAPSHOT.tar.gz
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 56.539 s
[INFO] Finished at: 2015-09-14T12:12:19-07:00
[INFO] Final Memory: 63M/260M
[INFO] ------------------------------------------------------------------------
```